### PR TITLE
Feature/input action map fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.2]
+
+### Fixed
+
+- Fixed execution order issue where another system may disable the input action map of this system. By default the input action map will be enabled and no longer disabled to avoid interfering with other systems that may use the same input action map.
+
 ## [2.2.1]
 
 ### Fixed

--- a/Runtime/Scripts/SelectionTools/PolygonInput.cs
+++ b/Runtime/Scripts/SelectionTools/PolygonInput.cs
@@ -143,6 +143,12 @@ namespace Netherlands3D.SelectionTools
             {
                 if (createHandles) Debug.Log("Please set a handleTemplate reference to create handles.", this.gameObject);
             }
+
+            if (!polygonSelectionActionMap.enabled)
+            {
+                Debug.LogWarning("polygonSelectionActionMap was not enabled, but assigned as the input action map. Enabling the input action map", this);
+                polygonSelectionActionMap.Enable();
+            }
         }
 
 #if UNITY_EDITOR
@@ -171,8 +177,6 @@ namespace Netherlands3D.SelectionTools
             clickAction.canceled += ClickAction_canceled;
             escapeAction.canceled += EscapeAction_canceled;
             finishAction.performed += FinishAction_performed;
-
-            polygonSelectionActionMap.Enable(); //make sure to look at the execution order in case there are multiple Scripts that make use of this ActionMap, OnDisable() of another object might be called after this function, resulting in no inputs being registered
         }
 
         protected virtual void OnDisable()
@@ -184,8 +188,6 @@ namespace Netherlands3D.SelectionTools
             clickAction.canceled -= ClickAction_canceled;
             escapeAction.canceled -= EscapeAction_canceled;
             finishAction.performed -= FinishAction_performed;
-
-            polygonSelectionActionMap.Disable();
         }
 
         private void TapAction_performed(InputAction.CallbackContext obj)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eu.netherlands3d.selection-tools",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "displayName": "Netherlands3D - Selection Tools",
   "description": "Tool to draw areas, and make selections",
   "unity": "2022.2",


### PR DESCRIPTION
Fixed execution order issue where another system may disable the input action map of this system. By default the input action map will be enabled and no longer disabled to avoid interfering with other systems that may use the same input action map.