### PR TITLE
Feature/open loop endpoint edit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.4]
+
+### Fixed
+
+- Fixed problem where dragging the end point of an open polygon (line) would also move the first point to the end position.
+
 ## [2.2.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed problem where dragging the end point of an open polygon (line) would also move the first point to the end position.
+- When performing the closing action with less than the minimum required points, a point is added at the cursor position to attempt to create a valid shape.
 
 ## [2.2.3]
 

--- a/Runtime/Scripts/SelectionTools/PolygonInput.cs
+++ b/Runtime/Scripts/SelectionTools/PolygonInput.cs
@@ -379,6 +379,11 @@ namespace Netherlands3D.SelectionTools
         {
             if (closedLoop)
                 return;
+            
+            if (positions.Count == minPointsToCloseLoop -1) // add an extra point at the current mouse position to attempt to create a valid shape
+            {
+                Tap();
+            }
 
             if (requireClosedPolygon)
             {

--- a/Runtime/Scripts/SelectionTools/PolygonInput.cs
+++ b/Runtime/Scripts/SelectionTools/PolygonInput.cs
@@ -416,9 +416,9 @@ namespace Netherlands3D.SelectionTools
                         positions.Add(closingLineEnd);
                     }
                 }
+                
+                closedLoop = true;
             }
-
-            closedLoop = true;
 
             FinishPolygon(isNewPolygon);
         }
@@ -577,7 +577,7 @@ namespace Netherlands3D.SelectionTools
             {
                 blockCameraDrag.Invoke(false);
 
-                if (!closedLoop) return;
+                if (!polygonFinished) return;
 
                 FinishPolygon(false);
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eu.netherlands3d.selection-tools",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "displayName": "Netherlands3D - Selection Tools",
   "description": "Tool to draw areas, and make selections",
   "unity": "2022.2",


### PR DESCRIPTION
Fixed problem where dragging the end point of an open polygon (line) would also move the first point to the end position.